### PR TITLE
Release on release-PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ['[0-9]+.[0-9]+.[0-9]+']
+  # Merging a release/<VERSION> PR is the release button: the internal repo
+  # opens that PR with the XCFramework committed; merging it when clients are
+  # ready triggers the tag + GitHub Release here.
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       version:
@@ -16,13 +22,17 @@ on:
 
 jobs:
   release:
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: macos-15
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ contains(github.ref, 'refs/tags/') && github.event.repository.default_branch || github.ref_name }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Resolve version
@@ -30,6 +40,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="${GITHUB_HEAD_REF#release/}"
           else
             VERSION=${GITHUB_REF_NAME}
           fi
@@ -81,8 +93,11 @@ jobs:
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: update Package.swift for ${TAG}"
           git tag -f "${TAG}"
-          BRANCH=${GITHUB_REF_NAME}
-          echo "${GITHUB_REF}" | grep -q "refs/tags/" && BRANCH=${{ github.event.repository.default_branch }}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            BRANCH=${GITHUB_REF_NAME}
+          else
+            BRANCH=${{ github.event.repository.default_branch }}
+          fi
           git push origin HEAD:${BRANCH}
           git push origin "${TAG}" --force
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.repository.default_branch }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.pull_request.merge_commit_sha || github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Resolve version


### PR DESCRIPTION
Merging a `release/<VERSION>` PR is now the release button: it triggers the existing zip/checksum/tag/Release job directly, replacing the manual workflow_dispatch step. Tag-push and dispatch triggers unchanged; idempotent (skips if the release exists).

Part of the release-flow inversion: internal merge = dev done (opens/updates the release PR), public merge = ship to clients.
